### PR TITLE
[TICKET_ID=146][MAJOR] - Sistema de proyectos ADEN, funcionando

### DIFF
--- a/models/aden_code_review.py
+++ b/models/aden_code_review.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+class CodeReview(models.Model):
+    _name = "aden_project.code_review"
+    _description = """
+    Seccion de code review para las tareas project.task para el sistema de proyectos de ADEN
+    """
+
+    name = fields.Char(string="Review", size=24, required=True)
+    date_of_review = fields.Datetime(string='Fecha revision', index=True, copy=False, tracking=True)
+    state_of_review = fields.Selection(
+        selection=[
+            ("in_review", "En Revision"),
+            ("approved", "Aprobado"),
+            ("rejected", "Rechazado"),
+        ], string="Estado de revision", default="in_review", tracking=True
+    ),
+    commentary = fields.Text(string="Comentarios"),
+    # TODO
+

--- a/models/aden_project_task.py
+++ b/models/aden_project_task.py
@@ -1,5 +1,8 @@
 from odoo import models, fields, api
 
+WARNING_MSG_NO_TEAM = "este usuario no esta asociado a un equipo, asegurate de agregarlo a uno"
+WARNING_MSG_TITLE_NO_TEAM = 'Usuario sin equipo!'
+
 
 class AdenTask(models.Model):
     _description = 'Customized version of project.task for ADEN'
@@ -19,8 +22,9 @@ class AdenTask(models.Model):
         string="Equipo asignado",
     )
 
+    # uses res.users instead of res.partner to not show the sales fields, etc
     resource_ids = fields.One2many(
-        comodel_name='aden_project.resources',  # uses res.users instead of res.partner to not show the sales fields, etc
+        comodel_name='aden_project.resources',
         inverse_name="task_id",
         string='Recurso',
     )
@@ -41,17 +45,16 @@ class AdenTask(models.Model):
         for task in self:
 
             if task.user_ids:
-                # toma al primer usuario en los user_ids
+                # take the first user of the user_ids task
                 first_user = task.user_ids[0]
 
                 if not first_user.team_id:
                     task.user_ids = False
-                    # muestra un pop up de error
+                    # shows a pop up error
                     return {
                         'warning': {
-                            'title': 'Usuario sin equipo!',
-                            'message': f"El usuario {first_user.name} no esta asociado a un equipo, asegurate de agregarlo a uno"}
+                            'title': WARNING_MSG_TITLE_NO_TEAM,
+                            'message': f"{first_user.name} {WARNING_MSG_NO_TEAM}"}
                     }
-
-                # asigna el equipo del usuario al equipo del la task
+                # assign the user team to the task
                 task.team_id = first_user.team_id

--- a/models/aden_resources.py
+++ b/models/aden_resources.py
@@ -23,7 +23,8 @@ class Recursos(models.Model):
         required=True,
     )
 
-    # ondelete="cascade" when you delete the task, the resource associated with that task are deleted also
+    # ondelete="cascade" when you delete the task,
+    # the resource associated with that task are deleted also
     task_id = fields.Many2one(
         string="Recursos",
         comodel_name="project.task",

--- a/models/aden_teams.py
+++ b/models/aden_teams.py
@@ -26,8 +26,9 @@ class Team(models.Model):
         readonly=True
     )
 
+    # uses res.users instead of res.partner to not show the sales fields, etc
     user_ids_members = fields.One2many(
-        comodel_name='res.users',  # uses res.users instead of res.partner to not show the sales fields, etc
+        comodel_name='res.users',
         inverse_name="team_id",
         string='Members',
         help='Team Members',

--- a/models/models.py
+++ b/models/models.py
@@ -16,4 +16,3 @@
 #     def _value_pc(self):
 #         for record in self:
 #             record.value2 = float(record.value) / 100
-

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,5 +1,8 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_aden_project_team,access aden_project.team,model_aden_project_team,base.group_user,1,0,0,0
+access_aden_project_team_user,aden_project.team_user,model_aden_project_team,project.group_project_user,1,1,0,0
+access_aden_project_team_manager,aden_project.team_manager,model_aden_project_team,project.group_project_manager,1,1,1,1
 access_aden_project_resources,access aden_project.resources,model_aden_project_resources,base.group_user,1,1,1,0
-access_aden_project_category,access aden_project.category,model_aden_project_category,base.group_user,1,0,0,0
-access_aden_project_subcategory,access aden_project.subcategory,model_aden_project_subcategory,base.group_user,1,0,0,0
+access_aden_project_category_user,aden_project.category_user,model_aden_project_category,project.group_project_user,1,1,0,0
+access_aden_project_category_manager,aden_project.category_manager,model_aden_project_category,project.group_project_manager,1,1,1,1
+access_aden_project_subcategory_user,aden_project.subcategory_user,model_aden_project_subcategory,project.group_project_user,1,1,0,0
+access_aden_project_subcategory_manager,aden_project.subcategory_manager,model_aden_project_subcategory,project.group_project_manager,1,1,1,1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/views/aden_project_task_views.xml
+++ b/views/aden_project_task_views.xml
@@ -11,6 +11,7 @@
             <xpath expr="//div[hasclass('oe_kanban_bottom_right')]" position="inside">
                 <group>
                     <field name="prioridad" />
+
                     <!-- agrego el equipo de forma invisible para que: 
                     cuando se asigna un usuario a una task en va lista kanban, 
                     tambien se le asigne el equipo, 
@@ -46,13 +47,22 @@
                 <field name="prioridad"/>
 
                 <!-- solo mostrar categorias que tengan el active en True -->
-                <field name="category_id" domain="[('activa', '=', True)]" />
-                <!-- <field name="category_id" domain="[('activa', '=', True)]" options="{'no_quick_create':True,'no_create_edit':True,'no_open': True,}"/> -->
+                <field 
+                name="category_id" 
+                domain="[('activa', '=', True)]" 
+                options="{'no_quick_create':True,'no_create_edit':True,'no_open': True,}"
+                />
 
                 <!-- solo se muestran las subcategorias que estan asociadas a la categoria seleccionada
                 solo mostrar subcategorias que tengan el active en True
-                si no hay una categoria seleccionada, hacer el campo subcategoria invisible -->
-                <field name="subcategory_id" domain="[('category_id', '=', category_id), ('activa', '=', True)]" invisible= "category_id == False" />
+                si no hay una categoria seleccionada, hacer el campo subcategoria invisible 
+                no permite ir a ver el form del modelo subcategoria con el options -->
+                <field 
+                name="subcategory_id" 
+                domain="[('category_id', '=', category_id), ('activa', '=', True)]" 
+                invisible= "category_id == False" 
+                options="{'no_quick_create':True,'no_create_edit':True,'no_open': True,}"
+                />
 
             </field>
 


### PR DESCRIPTION
## aden_project

En este PR se deja en funcionalidad los siguientes tickets

- https://pm.internal.aden.org/web#id=146&cids=1&menu_id=112&action=197&active_id=17&model=project.task&view_type=form
- https://pm.internal.aden.org/web#id=219&cids=1&menu_id=112&action=197&active_id=17&model=project.task&view_type=form


Agregue el modelo CodeReview, pero no va a ser importado ni utilizado en ninguna parte

## Arreglando permisos y linter

- Ahora en vez de utilizar el `base.group_users` utiliza `group_project_user` para los usuarios que van a utlizar dia a dia el sistema, con permisos limitados y `project.group_project_manager` que tiene permisos de administrador. Hereda de los grupos que ya estan definidos en el sistema de proyectos. 



- Constantes para los mensajes muy largos
- Comentarios en ingles
- Solo el administrador puede ver la estructura de la categoria y subcategoria, agregue unas `options` para que los usuarios no puedan ver la estructura de las mismas

NOTA: los recursos aun estan utilizando los permisos de base.group_users